### PR TITLE
Correct fragment indexing

### DIFF
--- a/crunpyroll/utils.py
+++ b/crunpyroll/utils.py
@@ -35,7 +35,7 @@ def parse_segments(repr: Dict, template: Dict) -> List[str]:
         duration = int(segment.get("@d"))
         time += repeat * duration
         for _ in range(repeat):
-            number = start_number + len(segments)
+            number = start_number + len(segments) - 1
             segment_url = format_segment_url(
                 url=base_url + template["@media"],
                 obj={


### PR DESCRIPTION
Segment urls were missing the first fragment (it was starting at fragment-2-...) and had an additional non-existent last fragment.

This patch corrects for this (did I make the change in the correct place?).