### PR TITLE
Add preferred_audio_language parameter (default ja-JP).

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ import asyncio
 client = crunpyroll.Client(
     email="email",
     password="password",
+    preferred_audio_language="ja-JP",
     locale="it-IT"
 )
 async def main():
@@ -47,7 +48,7 @@ async def main():
     query = await client.search("Attack On Titan")
     series_id = query.items[0].id
     print(series_id)
-    # Retrieve all seasons of the series
+    # Retrieve all seasons (with the preferred audio language) of the series
     seasons = await client.get_seasons(series_id)
     print(seasons)
 

--- a/crunpyroll/client.py
+++ b/crunpyroll/client.py
@@ -22,8 +22,11 @@ class Client(Object, Methods):
             Email or username of the account.
         password (``str``):
             Password of the account.
+        preferred_audio_language (``str``, *optional*):
+            The audio language to use in Crunchyroll.
+            Default to 'ja-JP'
         locale (``str``, *optional*):
-            The language to use in Crunchyroll.
+            The locale to use in Crunchyroll.
             Default to 'en-US'
         proxies (``str`` | ``dict``, *optional*):
             Proxies for HTTP requests.
@@ -34,11 +37,13 @@ class Client(Object, Methods):
         *,
         email: str,
         password: str,
+        preferred_audio_language: str = "ja-JP",
         locale: str = "en-US",
         proxies: Union[Dict, str] = None
     ) -> None:
         self.email: str = email
         self.password: str = password
+        self.preferred_audio_language: str = preferred_audio_language
         self.locale: str = locale
 
         self.http = httpx.AsyncClient(proxies=proxies, timeout=15)

--- a/crunpyroll/methods/get_seasons.py
+++ b/crunpyroll/methods/get_seasons.py
@@ -16,6 +16,9 @@ class GetSeasons:
         Parameters:
             series_id (``str``):
                 Unique identifier of the series.
+            preferred_audio_language (``str``, *optional*):
+                Audio language request for different results.
+                Default to the one used in Client.
             locale (``str``, *optional*):
                 Localize request for different results.
                 Default to the one used in Client.

--- a/crunpyroll/methods/get_seasons.py
+++ b/crunpyroll/methods/get_seasons.py
@@ -7,6 +7,7 @@ class GetSeasons:
         self: "crunpyroll.Client",
         series_id: str,
         *,
+        preferred_audio_language: str = None,
         locale: str = None,
     ) -> "types.SeasonsQuery":
         """
@@ -28,7 +29,8 @@ class GetSeasons:
             method="GET",
             endpoint="content/v2/cms/series/" + series_id + "/seasons",
             params={
-                "locale": locale or self.locale
+                "preferred_audio_language": preferred_audio_language or self.preferred_audio_language,
+                "locale": locale or self.locale,
             }
         )
         return types.SeasonsQuery.parse(response)


### PR DESCRIPTION
Foreign language dubs appear as a separate 'season' within the series.
Get_seasons method will now return list of seasons based on preferred_audio_language.

Prior to this commit, get_seasons was returning 'en-US' audio dubs, or the original audio language if the dub was not present.