### PR TITLE
Implement delete_active_stream method

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ cdm.parse_license(session_id, license)
 for key in cdm.get_keys(session_id, "CONTENT"):
     print(f"{key.kid.hex}:{key.key.hex()}")
 cdm.close(session_id)
+await client.delete_active_stream(
+    streams.media_id,
+    token=streams.token
+)
 ```
 Output:
 ```bash

--- a/crunpyroll/methods/__init__.py
+++ b/crunpyroll/methods/__init__.py
@@ -8,6 +8,7 @@ from .get_streams import GetStreams
 from .get_manifest import GetManifest
 from .get_license import GetLicense
 from .get_old_streams import GetOldStreams
+from .delete_active_stream import DeleteActiveStream
 
 class Methods(
     Search,
@@ -19,6 +20,7 @@ class Methods(
     GetStreams,
     GetManifest,
     GetLicense,
-    GetOldStreams
+    GetOldStreams,
+    DeleteActiveStream,
 ):
     pass

--- a/crunpyroll/methods/delete_active_stream.py
+++ b/crunpyroll/methods/delete_active_stream.py
@@ -1,0 +1,31 @@
+from crunpyroll import enums
+
+import crunpyroll
+
+class DeleteActiveStream:
+    async def delete_active_stream(
+        self: "crunpyroll.Client",
+        media_id: str,
+        *,
+        token: str,
+    ) -> str:
+        """
+        Delete an active stream.
+
+        Parameters:
+            media_id (``str``):
+                Unique identifier of the media.
+            token (``str``):
+                Token of the stream.
+
+        Returns:
+            ``str``:
+                On success, ??? is returned.
+        """
+        await self.session.retrieve()
+        response = await self.api_request(
+            method="DELETE",
+            endpoint="v1/token/" + media_id + "/" + token,
+            host=enums.APIHost.PLAY_SERVICE
+        )
+        return response


### PR DESCRIPTION
Deleting active streams will prevent Crunchyroll HTTP 420 (too_many_queued_streams) error.
Fixes #16, and #21.