### PR TITLE
fix for KeyError SegmentTemplate

### DIFF
--- a/crunpyroll/types/manifest.py
+++ b/crunpyroll/types/manifest.py
@@ -1,5 +1,6 @@
 from .obj import Object
 from .drm import ContentProtection
+from crunpyroll.types import SubtitlesStream
 
 from ..utils import (
     WIDEVINE_UUID,
@@ -22,6 +23,9 @@ class Manifest(Object):
         audio_streams (List of :obj:`~crunpyroll.types.ManifestAudioStream`):
             List of every audio stream available.
 
+        subs_streams (List of :obj:`~crunpyroll.types.SubtitleStream`):
+            List of every subtitle stream available
+
         content_protection (:obj:`~crunpyroll.types.ContentProtection`):
             Info about Content Protection (DRM).
 
@@ -30,8 +34,11 @@ class Manifest(Object):
             Useful for external downloader tools.
     """
     def __init__(self, data: Dict):
+
         self.video_streams: List["ManifestVideoStream"] = data.get("video_streams")
         self.audio_streams: List["ManifestAudioStream"] = data.get("audio_streams")
+        self.sub_streams : List["SubtitlesStream"] = data.get("subs_streams")
+
         self.content_protection: "ContentProtection" = ContentProtection(data.get("content_protection"))
         self.plain: str = data.get("plain")
 
@@ -41,26 +48,35 @@ class Manifest(Object):
         data["plain"] = obj
         data["video_streams"] = []
         data["audio_streams"] = []
+        data["subs_streams"] = []
         data["content_protection"] = {}
         manifest = xmltodict.parse(obj)
         for aset in manifest["MPD"]["Period"]["AdaptationSet"]:
-            template = aset["SegmentTemplate"]
-            for drm in aset["ContentProtection"]:
-                scheme_id_uri = drm["@schemeIdUri"]
-                if scheme_id_uri == WIDEVINE_UUID:
-                    data["content_protection"]["widevine"] = {}
-                    data["content_protection"]["widevine"]["pssh"] = drm["cenc:pssh"]
-                    data["content_protection"]["widevine"]["key_id"] = drm["@cenc:default_KID"]
-                if scheme_id_uri == PLAYREADY_UUID:
-                    data["content_protection"]["playready"] = {}
-                    data["content_protection"]["playready"]["pssh"] = drm["mspr:pro"]
-            for repr in aset["Representation"]:
-                if repr.get("@mimeType").startswith("video"):
-                    stream = ManifestVideoStream.parse(repr, template)
-                    data["video_streams"].append(stream)
-                elif repr.get("@mimeType").startswith("audio"):
-                    stream = ManifestAudioStream.parse(repr, template)
+            if "SegmentTemplate" in aset:
+                template = aset["SegmentTemplate"]
+                for drm in aset["ContentProtection"]:
+                    scheme_id_uri = drm["@schemeIdUri"]
+                    if scheme_id_uri == WIDEVINE_UUID:
+                        data["content_protection"]["widevine"] = {}
+                        data["content_protection"]["widevine"]["pssh"] = drm["cenc:pssh"]
+                        data["content_protection"]["widevine"]["key_id"] = drm["@cenc:default_KID"]
+                    if scheme_id_uri == PLAYREADY_UUID:
+                        data["content_protection"]["playready"] = {}
+                        data["content_protection"]["playready"]["pssh"] = drm["mspr:pro"]
+                for repr in aset["Representation"]:
+                    if repr.get("@mimeType").startswith("video"):
+                        stream = ManifestVideoStream.parse(repr, template)
+                        data["video_streams"].append(stream)
+                    elif repr.get("@mimeType").startswith("audio"):
+                        stream = ManifestAudioStream.parse(repr, template)
                     data["audio_streams"].append(stream)
+            else:
+                mimeType = aset.get("@mimeType")
+                if mimeType.startswith("text/vtt"): 
+                    repr = aset["Representation"]
+                    stream = SubtitlesStream(dict(format='vtt',language=aset["@lang"],url=repr["BaseURL"]))
+                    data["subs_streams"].append(stream)
+                        
         return cls(data)
 
 class ManifestVideoStream(Object):

--- a/crunpyroll/types/manifest.py
+++ b/crunpyroll/types/manifest.py
@@ -23,7 +23,7 @@ class Manifest(Object):
         audio_streams (List of :obj:`~crunpyroll.types.ManifestAudioStream`):
             List of every audio stream available.
 
-        subs_streams (List of :obj:`~crunpyroll.types.SubtitleStream`):
+        subs_streams (List of :obj:`~crunpyroll.types.SubtitlesStream`):
             List of every subtitle stream available
 
         content_protection (:obj:`~crunpyroll.types.ContentProtection`):

--- a/crunpyroll/utils.py
+++ b/crunpyroll/utils.py
@@ -2,13 +2,24 @@ from typing import Optional, List, Dict
 from datetime import datetime
 from uuid import uuid4
 
+import os
+
 PUBLIC_TOKEN = "bm12anNoZmtueW14eGtnN2ZiaDk6WllJVnJCV1VQYmNYRHRiRDIyVlNMYTZiNFdRb3Mzelg="
 
 APP_VERSION = "3.54.0"
 
 DEVICE_NAME = "RMX2170"
 DEVICE_TYPE = "realme RMX2170"
-DEVICE_ID = str(uuid4())
+
+# Store DEVICE ID to avoid creating a new one every time
+DEVICE_ID_PATH = os.path.join(os.environ.get("HOME"),".crunpyroll_device_id")
+if os.path.isfile(DEVICE_ID_PATH):
+    with open(DEVICE_ID_PATH, "r", encoding='utf-8') as f:
+        DEVICE_ID = f.read()
+else:
+    DEVICE_ID = str(uuid4())
+    with open(DEVICE_ID_PATH,"w",encoding="utf-8") as f:
+        f.write(DEVICE_ID)
 
 WIDEVINE_UUID = "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"
 PLAYREADY_UUID = "urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95"


### PR DESCRIPTION
When trying to obtain the manifest I would encounter a `KeyError` with the `SegmentTemplate` key. That happened when parsing the MPD file if there was a subtitle stream in the manifest. The fix I propose is to check if the `SegmentTemplate` key exists (that means that the aset is either a video or audio stream), and if that is not the case, then it falls into a subtitle stream for which I added a list in the Manifest class.